### PR TITLE
trying to build / error check again

### DIFF
--- a/Network/network-exchange-clc-endpoint-guide.md
+++ b/Network/network-exchange-clc-endpoint-guide.md
@@ -1,6 +1,6 @@
 {{{
   "title": "Network Exchange CenturyLink Cloud Endpoint Guide",
-  "date": "05-07-2018",
+  "date": "05-08-2018",
   "author": "Jason Holland",
   "attachments": [],
   "related-products" : [],


### PR DESCRIPTION
error check keeps failing on unrelated error:

File '/home/travis/build/CenturyLinkCloud/PublicKB/Cloud Application Manager/Managed Services/Supporting\ AWS\ Accounts\ in\ an\ Organization' not found. Is there a file extension? Are the file extension and path correct? (Referenced from '/home/travis/build/CenturyLinkCloud/PublicKB/Cloud Application Manager/Managed Services/MSAAWSBYOCKB.md')